### PR TITLE
Fix tests

### DIFF
--- a/all_minilm_l6_v2/benchmark_test.go
+++ b/all_minilm_l6_v2/benchmark_test.go
@@ -14,6 +14,7 @@ func newModel(t *testing.B) *all_minilm_l6_v2.Model {
 	}
 	t.Cleanup(func() {
 		benchModel.Close()
+		all_minilm_l6_v2.DestroyOrtEnv()
 	})
 	return benchModel
 }

--- a/all_minilm_l6_v2/model.go
+++ b/all_minilm_l6_v2/model.go
@@ -102,6 +102,11 @@ func (m *Model) Close() {
 	}
 }
 
+func (m *Model) DestroyOrtEnv() error {
+	err := ort.DestroyEnvironment()
+	return err
+}
+
 func (m *Model) Compute(sentence string, addSpecialTokens bool) ([]float32, error) {
 	results, err := m.ComputeBatch([]string{sentence}, addSpecialTokens)
 	if err != nil {

--- a/all_minilm_l6_v2/model.go
+++ b/all_minilm_l6_v2/model.go
@@ -102,7 +102,7 @@ func (m *Model) Close() {
 	}
 }
 
-func (m *Model) DestroyOrtEnv() error {
+func DestroyOrtEnv() error {
 	err := ort.DestroyEnvironment()
 	return err
 }

--- a/all_minilm_l6_v2/model_test.go
+++ b/all_minilm_l6_v2/model_test.go
@@ -12,7 +12,7 @@ func TestSingleSentenceEmbedding(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create model: %v", err)
 	}
-	defer model.Close()
+	defer closeAndDestroy(model)
 
 	sentence := "Hello, world! This is a test sentence."
 	embedding, err := model.Compute(sentence, false)
@@ -54,7 +54,7 @@ func TestBatchEmbedding(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create model: %v", err)
 	}
-	defer model.Close()
+	defer closeAndDestroy(model)
 
 	sentences := []string{
 		"Hello, world! This is a test sentence.",
@@ -117,7 +117,7 @@ func TestConsistentEmbeddingForSameSentence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create model: %v", err)
 	}
-	defer model.Close()
+	defer closeAndDestroy(model)
 
 	// Test with same sentence appearing twice in batch, plus a different sentence
 	sentences := []string{
@@ -172,7 +172,7 @@ func TestSingleVsBatchConsistency(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create model: %v", err)
 	}
-	defer model.Close()
+	defer closeAndDestroy(model)
 
 	sentence := "Testing consistency between single and batch computation."
 
@@ -203,7 +203,7 @@ func TestEmptyBatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create model: %v", err)
 	}
-	defer model.Close()
+	defer closeAndDestroy(model)
 
 	// Test empty batch
 	embeddings, err := model.ComputeBatch([]string{}, false)
@@ -229,4 +229,10 @@ func vectorsEqual(a, b []float32) bool {
 		}
 	}
 	return true
+}
+
+// Helper function to close the model and destroy its env
+func closeAndDestroy(m *all_minilm_l6_v2.Model) {
+	m.Close()
+	m.DestroyOrtEnv()
 }

--- a/all_minilm_l6_v2/model_test.go
+++ b/all_minilm_l6_v2/model_test.go
@@ -234,5 +234,5 @@ func vectorsEqual(a, b []float32) bool {
 // Helper function to close the model and destroy its env
 func closeAndDestroy(m *all_minilm_l6_v2.Model) {
 	m.Close()
-	m.DestroyOrtEnv()
+	all_minilm_l6_v2.DestroyOrtEnv()
 }


### PR DESCRIPTION
Fixed a conflict where the global ONNX Runtime environment was persisting between test cases after my #2 (sorry, i didn't foresee that - my original goal was to make the model work). Added DestroyOrtEnv() to allow manual lifecycle management of the ORT environment, ensuring tests can run in isolation without "already initialized" errors.
```
=== RUN   TestSingleSentenceEmbedding
--- PASS: TestSingleSentenceEmbedding (0.27s)
=== RUN   TestBatchEmbedding
--- PASS: TestBatchEmbedding (0.24s)
=== RUN   TestConsistentEmbeddingForSameSentence
--- PASS: TestConsistentEmbeddingForSameSentence (0.22s)
=== RUN   TestSingleVsBatchConsistency
--- PASS: TestSingleVsBatchConsistency (0.21s)
=== RUN   TestEmptyBatch
--- PASS: TestEmptyBatch (0.20s)
PASS
```